### PR TITLE
Remove scalar

### DIFF
--- a/ijzer/src/ast_node.rs
+++ b/ijzer/src/ast_node.rs
@@ -118,7 +118,6 @@ fn infer_output_number_type(operands: &Vec<Rc<Node>>, output_type: IJType) -> Re
             }
             match output_type {
                 IJType::Tensor(None) => Ok(IJType::Tensor(number_type)),
-                IJType::Scalar(None) => Ok(IJType::Scalar(number_type)),
                 IJType::Number(None) => Ok(IJType::Number(number_type)),
                 _ => unreachable!(),
             }

--- a/ijzer/src/compiler.rs
+++ b/ijzer/src/compiler.rs
@@ -1330,7 +1330,7 @@ mod tests {
     fn test_assign_tensor() {
         let input1 = "x: T<_> = [1]<_>";
         let input2 = "x = [1]<_>";
-        let expected = "let x : ijzer :: tensor :: Tensor :: < _ > = ijzer :: tensor :: Tensor :: < _ > :: from_vec (vec ! [ijzer :: tensor :: Tensor :: < _ > :: scalar (1) . extract_scalar () . unwrap ()] , None) ;";
+        let expected = "let x : ijzer :: tensor :: Tensor :: < _ > = ijzer :: tensor :: Tensor :: < _ > :: from_vec (vec ! [1 as _] , None) ;";
         compiler_compare(input1, expected);
         compiler_compare(input2, expected);
     }

--- a/ijzer/src/compiler.rs
+++ b/ijzer/src/compiler.rs
@@ -956,7 +956,7 @@ impl CompileNode for GeneralizedContraction {
         let f_arg_annot =
             annotation_from_type(&f_node.output_type.extract_signature().unwrap().input[0])?;
         let f_stream_extract = quote! {
-            (|z: &#f_arg_annot| (#f_stream)(z.clone()).extract_scalar().unwrap())
+            (|z: &#f_arg_annot| (#f_stream)(z.clone()))
         };
         let g_stream = child_streams[1].clone();
         let g_node = &node.operands[1];
@@ -1238,19 +1238,14 @@ impl CompileNode for Index {
             .iter()
             .any(|n| n.output_type.type_match(&IJType::Void));
 
-        let tensor_t = annotation_from_type(&tensor_operand.output_type)?;
         match (all_numbers, contains_colon) {
             (true, _) => {
                 let index_operands_stream = index_operands
                     .iter()
                     .map(|n| child_streams.get(&n.id).unwrap().clone())
                     .collect::<Vec<TokenStream>>();
-                let index_operands_stream = index_operands_stream
-                    .iter()
-                    .map(|n| quote! {#n.extract_scalar().unwrap()})
-                    .collect::<Vec<TokenStream>>();
                 Ok(quote! {
-                    #tensor_t::scalar(#tensor_stream[&vec![#(#index_operands_stream),*]].clone())
+                    #tensor_stream[&vec![#(#index_operands_stream),*]].clone()
                 })
             }
             (false, true) => {

--- a/ijzer/src/operations.rs
+++ b/ijzer/src/operations.rs
@@ -32,6 +32,7 @@ pub enum Operation {
     Solve,
     Diag,
     Index,
+    AssignSymbol(String),
 }
 
 impl Debug for Operation {
@@ -65,6 +66,7 @@ impl Debug for Operation {
             Self::Solve => write!(f, r"\"),
             Self::Diag => write!(f, "diag"),
             Self::Index => write!(f, "<|"),
+            Self::AssignSymbol(s) => write!(f, "AssignSymbol({})", s),
         }
     }
 }

--- a/ijzer/src/parser/apply.rs
+++ b/ijzer/src/parser/apply.rs
@@ -54,7 +54,7 @@ mod tests {
 
     #[test]
     fn test_apply() -> Result<()> {
-        let (node, _) = parse_str_no_context(".~+:Fn(S,S->S) 1 2")?;
+        let (node, _) = parse_str_no_context(".~+:Fn(N,N->N) 1 2")?;
         assert_eq!(node.op, Operation::Apply);
         assert_eq!(node.operands.len(), 3);
         Ok(())
@@ -63,7 +63,7 @@ mod tests {
     #[test]
     fn test_apply_with_var() -> Result<()> {
         let mut context = ASTContext::new();
-        parse_str("var f: Fn(S,S->S)", &mut context)?;
+        parse_str("var f: Fn(N,N->N)", &mut context)?;
 
         let node = parse_str(".~f 1 2", &mut context)?;
         assert_eq!(node.op, Operation::Apply);
@@ -105,7 +105,7 @@ mod tests {
     #[test]
     fn test_apply_function() -> Result<()> {
         let mut context = ASTContext::new();
-        parse_str("var f: Fn(N->N->N)", &mut context)?;
+        parse_str("var f: Fn(N->Fn(N->N))", &mut context)?;
 
         let node = parse_str(".(f 1) 2", &mut context)?;
         assert_eq!(node.op, Operation::Apply);

--- a/ijzer/src/parser/apply.rs
+++ b/ijzer/src/parser/apply.rs
@@ -74,19 +74,19 @@ mod tests {
     #[test]
     fn test_apply_with_type() -> Result<()> {
         let mut context = ASTContext::new();
-        parse_str("var f: Fn(S,S->S)", &mut context)?;
+        parse_str("var f: Fn(N,N->N)", &mut context)?;
 
         let node = parse_str(".~f 1<i64> 2", &mut context)?;
         assert_eq!(node.op, Operation::Apply);
-        assert_eq!(node.output_type, IJType::Scalar(Some("i64".to_string())));
+        assert_eq!(node.output_type, IJType::Number(Some("i64".to_string())));
         assert_eq!(node.operands.len(), 3);
 
         let mut context = ASTContext::new();
-        parse_str("var f: Fn(S<a>,S<b>->S<c>)", &mut context)?;
+        parse_str("var f: Fn(N<a>,N<b>->N<c>)", &mut context)?;
 
         let node = parse_str(".~f 1<a> 2<b>", &mut context)?;
         assert_eq!(node.op, Operation::Apply);
-        assert_eq!(node.output_type, IJType::Scalar(Some("c".to_string())));
+        assert_eq!(node.output_type, IJType::Number(Some("c".to_string())));
         assert_eq!(node.operands.len(), 3);
         Ok(())
     }
@@ -94,7 +94,7 @@ mod tests {
     #[test]
     fn test_apply_with_composition() -> Result<()> {
         let mut context = ASTContext::new();
-        parse_str("var f: Fn(S,S->S)", &mut context)?;
+        parse_str("var f: Fn(N,N->N)", &mut context)?;
 
         let node = parse_str(".~@(-,f) 1 2", &mut context)?;
         assert_eq!(node.op, Operation::Apply);
@@ -105,7 +105,7 @@ mod tests {
     #[test]
     fn test_apply_function() -> Result<()> {
         let mut context = ASTContext::new();
-        parse_str("var f: Fn(S->Fn(S->S))", &mut context)?;
+        parse_str("var f: Fn(N->N->N)", &mut context)?;
 
         let node = parse_str(".(f 1) 2", &mut context)?;
         assert_eq!(node.op, Operation::Apply);

--- a/ijzer/src/parser/array.rs
+++ b/ijzer/src/parser/array.rs
@@ -28,7 +28,7 @@ impl ParseNode for LSqBracket {
             .into_iter()
             .map(|s| {
                 let (operands, remainder) = gather_operands(
-                    vec![vec![IJType::Tensor(None)], vec![IJType::Scalar(None)]],
+                    vec![vec![IJType::Tensor(None)], vec![IJType::Number(None)]],
                     s,
                     context,
                 )?;

--- a/ijzer/src/parser/as_function.rs
+++ b/ijzer/src/parser/as_function.rs
@@ -99,18 +99,18 @@ mod tests {
     #[test]
     fn test_as_function_simple() -> Result<()> {
         let mut context = ASTContext::new();
-        parse_str("var f: Fn(S,S->S)", &mut context)?;
+        parse_str("var f: Fn(N,N->N)", &mut context)?;
 
         let node = parse_str("~f", &mut context)?;
         assert_eq!(node.op, Operation::Function("f".to_string()));
-        assert_eq!(node.output_type, IJType::scalar_function(2));
+        assert_eq!(node.output_type, IJType::number_function(2));
         Ok(())
     }
 
     #[test]
     fn test_as_function_with_type() -> Result<()> {
         let mut context = ASTContext::new();
-        parse_str("var f: Fn(S<a>,S<b>->S<c>)", &mut context)?;
+        parse_str("var f: Fn(N<a>,N<b>->N<c>)", &mut context)?;
 
         let node = parse_str("~f", &mut context)?;
         assert_eq!(node.op, Operation::Function("f".to_string()));
@@ -118,10 +118,10 @@ mod tests {
             node.output_type,
             IJType::Function(FunctionSignature::new(
                 vec![
-                    IJType::Scalar(Some("a".to_string())),
-                    IJType::Scalar(Some("b".to_string()))
+                    IJType::Number(Some("a".to_string())),
+                    IJType::Number(Some("b".to_string()))
                 ],
-                IJType::Scalar(Some("c".to_string()))
+                IJType::Number(Some("c".to_string()))
             ))
         );
         Ok(())
@@ -129,10 +129,10 @@ mod tests {
 
     #[test]
     fn test_as_function_declaration() -> Result<()> {
-        let (node, _) = parse_str_no_context("~+:Fn(S,S->S)")?;
+        let (node, _) = parse_str_no_context("~+:Fn(N,N->N)")?;
 
         assert_eq!(node.op, Operation::Add);
-        assert_eq!(node.output_type, IJType::scalar_function(2));
+        assert_eq!(node.output_type, IJType::number_function(2));
         Ok(())
     }
 
@@ -152,7 +152,7 @@ mod tests {
             node.output_type,
             IJType::Function(FunctionSignature::new(
                 vec![IJType::Tensor(None)],
-                IJType::Scalar(None)
+                IJType::Number(None)
             ))
         );
         Ok(())
@@ -160,10 +160,10 @@ mod tests {
 
     #[test]
     fn test_as_function_double() -> Result<()> {
-        let (node, _) = parse_str_no_context("~~+:Fn(S,S->S)")?;
+        let (node, _) = parse_str_no_context("~~+:Fn(N,N->N)")?;
 
         assert_eq!(node.op, Operation::Add);
-        assert_eq!(node.output_type, IJType::scalar_function(2));
+        assert_eq!(node.output_type, IJType::number_function(2));
         Ok(())
     }
 }

--- a/ijzer/src/parser/assign.rs
+++ b/ijzer/src/parser/assign.rs
@@ -209,7 +209,7 @@ pub fn parse_group_assign(
                 }
             }
             symbol_nodes.push(Rc::new(Node::new(
-                Operation::Symbol(lhs_name.clone()),
+                Operation::AssignSymbol(lhs_name.clone()),
                 vec![],
                 rhs_type.clone(),
                 vec![],
@@ -284,7 +284,7 @@ pub fn parse_assign(context: &mut ASTContext) -> Result<Rc<Node>> {
         }
     }
     let symbol_node = Rc::new(Node::new(
-        Operation::Symbol(symbol_name.clone()),
+        Operation::AssignSymbol(symbol_name.clone()),
         vec![],
         symbol_type.clone(),
         vec![],
@@ -422,7 +422,7 @@ mod tests {
         let node = parse_assign(&mut context)?;
         assert_eq!(node.op, Operation::Assign);
         assert_eq!(node.operands.len(), 2);
-        assert_eq!(node.operands[0].op, Operation::Symbol("g".to_string()));
+        assert_eq!(node.operands[0].op, Operation::AssignSymbol("g".to_string()));
         assert_eq!(node.operands[0].output_type, IJType::Tensor(None));
         assert_eq!(node.operands[1].op, Operation::Array);
         assert_eq!(node.operands[1].output_type, IJType::Tensor(None));
@@ -436,7 +436,7 @@ mod tests {
         let node = parse_assign(&mut context)?;
         assert_eq!(node.op, Operation::Assign);
         assert_eq!(node.operands.len(), 2);
-        assert_eq!(node.operands[0].op, Operation::Symbol("g".to_string()));
+        assert_eq!(node.operands[0].op, Operation::AssignSymbol("g".to_string()));
         assert_eq!(node.operands[0].output_type, IJType::Tensor(None));
         assert_eq!(node.operands[1].op, Operation::Array);
         assert_eq!(node.operands[1].output_type, IJType::Tensor(None));
@@ -451,7 +451,7 @@ mod tests {
         let node = parse_assign(&mut context)?;
         assert_eq!(node.op, Operation::Assign);
         assert_eq!(node.operands.len(), 2);
-        assert_eq!(node.operands[0].op, Operation::Symbol("g".to_string()));
+        assert_eq!(node.operands[0].op, Operation::AssignSymbol("g".to_string()));
         assert_eq!(node.operands[0].output_type, IJType::Number(None));
         assert_eq!(node.operands[1].output_type, IJType::Number(None));
         Ok(())
@@ -482,7 +482,7 @@ mod tests {
         println!("{:?}", node);
         assert_eq!(node.op, Operation::Assign);
         assert_eq!(node.operands.len(), 3);
-        assert_eq!(node.operands[0].op, Operation::Symbol("g".to_string()));
+        assert_eq!(node.operands[0].op, Operation::AssignSymbol("g".to_string()));
         assert_eq!(
             node.operands[0].output_type,
             IJType::Function(FunctionSignature::new(
@@ -503,7 +503,7 @@ mod tests {
         println!("{:?}", node);
         assert_eq!(node.op, Operation::Assign);
         assert_eq!(node.operands.len(), 3);
-        assert_eq!(node.operands[0].op, Operation::Symbol("g".to_string()));
+        assert_eq!(node.operands[0].op, Operation::AssignSymbol("g".to_string()));
         assert_eq!(
             node.operands[0].output_type,
             IJType::Function(FunctionSignature::new(
@@ -523,7 +523,7 @@ mod tests {
         println!("{:?}", node);
         assert_eq!(node.op, Operation::Assign);
         assert_eq!(node.operands.len(), 3);
-        assert_eq!(node.operands[0].op, Operation::Symbol("g".to_string()));
+        assert_eq!(node.operands[0].op, Operation::AssignSymbol("g".to_string()));
         assert_eq!(
             node.operands[0].output_type,
             IJType::Function(FunctionSignature::new(
@@ -550,7 +550,7 @@ mod tests {
         println!("{:?}", node);
         assert_eq!(node.op, Operation::Assign);
         assert_eq!(node.operands.len(), 3);
-        assert_eq!(node.operands[0].op, Operation::Symbol("g".to_string()));
+        assert_eq!(node.operands[0].op, Operation::AssignSymbol("g".to_string()));
         assert_eq!(
             node.operands[0].output_type,
             IJType::Function(FunctionSignature::new(
@@ -571,7 +571,7 @@ mod tests {
         println!("{:?}", node);
         assert_eq!(node.op, Operation::Assign);
         assert_eq!(node.operands.len(), 3);
-        assert_eq!(node.operands[0].op, Operation::Symbol("g".to_string()));
+        assert_eq!(node.operands[0].op, Operation::AssignSymbol("g".to_string()));
         assert_eq!(
             node.operands[0].output_type,
             IJType::Function(FunctionSignature::new(
@@ -592,7 +592,7 @@ mod tests {
         println!("{:?}", node);
         assert_eq!(node.op, Operation::Assign);
         assert_eq!(node.operands.len(), 3);
-        assert_eq!(node.operands[0].op, Operation::Symbol("g".to_string()));
+        assert_eq!(node.operands[0].op, Operation::AssignSymbol("g".to_string()));
         assert_eq!(
             node.operands[0].output_type,
             IJType::Function(FunctionSignature::new(
@@ -613,7 +613,7 @@ mod tests {
         println!("{:?}", node);
         assert_eq!(node.op, Operation::Assign);
         assert_eq!(node.operands.len(), 4);
-        assert_eq!(node.operands[0].op, Operation::Symbol("g".to_string()));
+        assert_eq!(node.operands[0].op, Operation::AssignSymbol("g".to_string()));
         assert_eq!(
             node.operands[0].output_type,
             IJType::Function(FunctionSignature::new(
@@ -635,7 +635,7 @@ mod tests {
         println!("{:?}", node);
         assert_eq!(node.op, Operation::Assign);
         assert_eq!(node.operands.len(), 3);
-        assert_eq!(node.operands[0].op, Operation::Symbol("g".to_string()));
+        assert_eq!(node.operands[0].op, Operation::AssignSymbol("g".to_string()));
         assert_eq!(
             node.operands[0].output_type,
             IJType::Function(FunctionSignature::new(
@@ -665,7 +665,7 @@ mod tests {
         println!("{:?}", node);
         assert_eq!(node.op, Operation::Assign);
         assert_eq!(node.operands.len(), 4);
-        assert_eq!(node.operands[0].op, Operation::Symbol("g".to_string()));
+        assert_eq!(node.operands[0].op, Operation::AssignSymbol("g".to_string()));
         assert_eq!(
             node.operands[0].output_type,
             IJType::Function(FunctionSignature::new(

--- a/ijzer/src/parser/assign.rs
+++ b/ijzer/src/parser/assign.rs
@@ -586,7 +586,7 @@ mod tests {
 
     #[test]
     fn test_assign_simple_reuse_var_annotated() -> Result<()> {
-        let tokens = lexer("g($x:N) -> N = /+ + $x $x")?;
+        let tokens = lexer("g($x:T) -> N = /+ + $x $x")?;
         let mut context = ASTContext::from_tokens(tokens.clone());
         let node = parse_assign(&mut context)?;
         println!("{:?}", node);
@@ -629,7 +629,7 @@ mod tests {
 
     #[test]
     fn test_assign_functional_args() -> Result<()> {
-        let tokens = lexer("g($x:Fn(N,N->N)) -> S = /$x [1]")?;
+        let tokens = lexer("g($x:Fn(N,N->N)) -> N = /$x [1]")?;
         let mut context = ASTContext::from_tokens(tokens.clone());
         let node = parse_assign(&mut context)?;
         println!("{:?}", node);

--- a/ijzer/src/parser/assign.rs
+++ b/ijzer/src/parser/assign.rs
@@ -354,7 +354,7 @@ mod tests {
 
     #[test]
     fn test_parse_assign_args_type() -> Result<()> {
-        let tokens = lexer("g($x: T, $y: S)")?;
+        let tokens = lexer("g($x: T, $y: N)")?;
         let mut context = ASTContext::from_tokens(tokens.clone());
         let slice = context.full_slice();
         let (symbol_name, args, output_type) = parse_assign_lhs(&mut context, slice)?;
@@ -363,7 +363,7 @@ mod tests {
         let arg0 = args[0].clone();
         assert_eq!(arg0.output_type, IJType::Tensor(None));
         let arg1 = args[1].clone();
-        assert_eq!(arg1.output_type, IJType::Scalar(None));
+        assert_eq!(arg1.output_type, IJType::Number(None));
         assert_eq!(output_type, None);
 
         Ok(())
@@ -371,7 +371,7 @@ mod tests {
 
     #[test]
     fn test_parse_assign_args_type_output_arrow() -> Result<()> {
-        let tokens = lexer("g($x: T, $y: S) -> T")?;
+        let tokens = lexer("g($x: T, $y: N) -> T")?;
         let mut context = ASTContext::from_tokens(tokens.clone());
         let slice = context.full_slice();
         let (symbol_name, args, output_type) = parse_assign_lhs(&mut context, slice)?;
@@ -380,11 +380,11 @@ mod tests {
         let arg0 = args[0].clone();
         assert_eq!(arg0.output_type, IJType::Tensor(None));
         let arg1 = args[1].clone();
-        assert_eq!(arg1.output_type, IJType::Scalar(None));
+        assert_eq!(arg1.output_type, IJType::Number(None));
         assert_eq!(
             output_type,
             Some(IJType::Function(FunctionSignature::new(
-                vec![IJType::Tensor(None), IJType::Scalar(None)],
+                vec![IJType::Tensor(None), IJType::Number(None)],
                 IJType::Tensor(None)
             )))
         );
@@ -394,7 +394,7 @@ mod tests {
 
     #[test]
     fn test_parse_assign_args_type_output_declaration() -> Result<()> {
-        let tokens = lexer("g($x: T, $y: S): Fn(T,S->T)")?;
+        let tokens = lexer("g($x: T, $y: N): Fn(T,N->T)")?;
         let mut context = ASTContext::from_tokens(tokens.clone());
         let slice = context.full_slice();
         let (symbol_name, args, output_type) = parse_assign_lhs(&mut context, slice)?;
@@ -403,11 +403,11 @@ mod tests {
         let arg0 = args[0].clone();
         assert_eq!(arg0.output_type, IJType::Tensor(None));
         let arg1 = args[1].clone();
-        assert_eq!(arg1.output_type, IJType::Scalar(None));
+        assert_eq!(arg1.output_type, IJType::Number(None));
         assert_eq!(
             output_type,
             Some(IJType::Function(FunctionSignature::new(
-                vec![IJType::Tensor(None), IJType::Scalar(None)],
+                vec![IJType::Tensor(None), IJType::Number(None)],
                 IJType::Tensor(None)
             )))
         );
@@ -452,24 +452,24 @@ mod tests {
         assert_eq!(node.op, Operation::Assign);
         assert_eq!(node.operands.len(), 2);
         assert_eq!(node.operands[0].op, Operation::Symbol("g".to_string()));
-        assert_eq!(node.operands[0].output_type, IJType::Scalar(None));
-        assert_eq!(node.operands[1].output_type, IJType::Scalar(None));
+        assert_eq!(node.operands[0].output_type, IJType::Number(None));
+        assert_eq!(node.operands[1].output_type, IJType::Number(None));
         Ok(())
     }
 
     #[test]
     fn test_assign_simple_scalar_with_number_type() -> Result<()> {
-        let tokens = lexer("g: S<i64> = 1<i64>")?;
+        let tokens = lexer("g: N<i64> = 1<i64>")?;
         let mut context = ASTContext::from_tokens(tokens.clone());
         let node = parse_assign(&mut context)?;
         assert_eq!(node.op, Operation::Assign);
         assert_eq!(
             node.operands[0].output_type,
-            IJType::Scalar(Some("i64".to_string()))
+            IJType::Number(Some("i64".to_string()))
         );
         assert_eq!(
             node.operands[1].output_type,
-            IJType::Scalar(Some("i64".to_string()))
+            IJType::Number(Some("i64".to_string()))
         );
         Ok(())
     }
@@ -497,7 +497,7 @@ mod tests {
 
     #[test]
     fn test_assign_simple_function_scalar() -> Result<()> {
-        let tokens = lexer("g($x: S) = $x")?;
+        let tokens = lexer("g($x: N) = $x")?;
         let mut context = ASTContext::from_tokens(tokens.clone());
         let node = parse_assign(&mut context)?;
         println!("{:?}", node);
@@ -507,17 +507,17 @@ mod tests {
         assert_eq!(
             node.operands[0].output_type,
             IJType::Function(FunctionSignature::new(
-                vec![IJType::Scalar(None)],
-                IJType::Scalar(None)
+                vec![IJType::Number(None)],
+                IJType::Number(None)
             ))
         );
-        assert_eq!(node.operands[1].output_type, IJType::Scalar(None));
-        assert_eq!(node.operands[2].output_type, IJType::Scalar(None));
+        assert_eq!(node.operands[1].output_type, IJType::Number(None));
+        assert_eq!(node.operands[2].output_type, IJType::Number(None));
         Ok(())
     }
     #[test]
     fn test_assign_simple_function_scalar_with_number_type() -> Result<()> {
-        let tokens = lexer("g($x: S<i64>) = $x")?;
+        let tokens = lexer("g($x: N<i64>) = $x")?;
         let mut context = ASTContext::from_tokens(tokens.clone());
         let node = parse_assign(&mut context)?;
         println!("{:?}", node);
@@ -527,17 +527,17 @@ mod tests {
         assert_eq!(
             node.operands[0].output_type,
             IJType::Function(FunctionSignature::new(
-                vec![IJType::Scalar(Some("i64".to_string()))],
-                IJType::Scalar(Some("i64".to_string()))
+                vec![IJType::Number(Some("i64".to_string()))],
+                IJType::Number(Some("i64".to_string()))
             ))
         );
         assert_eq!(
             node.operands[1].output_type,
-            IJType::Scalar(Some("i64".to_string()))
+            IJType::Number(Some("i64".to_string()))
         );
         assert_eq!(
             node.operands[2].output_type,
-            IJType::Scalar(Some("i64".to_string()))
+            IJType::Number(Some("i64".to_string()))
         );
         Ok(())
     }
@@ -555,10 +555,10 @@ mod tests {
             node.operands[0].output_type,
             IJType::Function(FunctionSignature::new(
                 vec![IJType::Tensor(None)],
-                IJType::Scalar(None)
+                IJType::Number(None)
             ))
         );
-        assert_eq!(node.operands[1].output_type, IJType::Scalar(None));
+        assert_eq!(node.operands[1].output_type, IJType::Number(None));
         assert_eq!(node.operands[2].output_type, IJType::Tensor(None));
         Ok(())
     }
@@ -586,7 +586,7 @@ mod tests {
 
     #[test]
     fn test_assign_simple_reuse_var_annotated() -> Result<()> {
-        let tokens = lexer("g($x:T) -> S = /+ + $x $x")?;
+        let tokens = lexer("g($x:N) -> N = /+ + $x $x")?;
         let mut context = ASTContext::from_tokens(tokens.clone());
         let node = parse_assign(&mut context)?;
         println!("{:?}", node);
@@ -597,17 +597,17 @@ mod tests {
             node.operands[0].output_type,
             IJType::Function(FunctionSignature::new(
                 vec![IJType::Tensor(None)],
-                IJType::Scalar(None)
+                IJType::Number(None)
             ))
         );
-        assert_eq!(node.operands[1].output_type, IJType::Scalar(None));
+        assert_eq!(node.operands[1].output_type, IJType::Number(None));
         assert_eq!(node.operands[2].output_type, IJType::Tensor(None));
         Ok(())
     }
 
     #[test]
     fn test_assign_multiple_args() -> Result<()> {
-        let tokens = lexer("g($x:T, $y:S) -> S = /+ + $x $y")?;
+        let tokens = lexer("g($x:T, $y:N) -> N = /+ + $x $y")?;
         let mut context = ASTContext::from_tokens(tokens.clone());
         let node = parse_assign(&mut context)?;
         println!("{:?}", node);
@@ -617,13 +617,13 @@ mod tests {
         assert_eq!(
             node.operands[0].output_type,
             IJType::Function(FunctionSignature::new(
-                vec![IJType::Tensor(None), IJType::Scalar(None)],
-                IJType::Scalar(None)
+                vec![IJType::Tensor(None), IJType::Number(None)],
+                IJType::Number(None)
             ))
         );
-        assert_eq!(node.operands[1].output_type, IJType::Scalar(None));
+        assert_eq!(node.operands[1].output_type, IJType::Number(None));
         assert_eq!(node.operands[2].output_type, IJType::Tensor(None));
-        assert_eq!(node.operands[3].output_type, IJType::Scalar(None));
+        assert_eq!(node.operands[3].output_type, IJType::Number(None));
         Ok(())
     }
 
@@ -643,10 +643,10 @@ mod tests {
                     vec![IJType::Number(None), IJType::Number(None)],
                     IJType::Number(None),
                 ))],
-                IJType::Scalar(None)
+                IJType::Number(None)
             ))
         );
-        assert_eq!(node.operands[1].output_type, IJType::Scalar(None));
+        assert_eq!(node.operands[1].output_type, IJType::Number(None));
         assert_eq!(
             node.operands[2].output_type,
             IJType::Function(FunctionSignature::new(
@@ -659,7 +659,7 @@ mod tests {
 
     #[test]
     fn test_assign_functional_args_composition() -> Result<()> {
-        let tokens = lexer("g($x:Fn(S->T), $y:Fn(T->S)) -> Fn(T->T) = ~@($x,$y)")?;
+        let tokens = lexer("g($x:Fn(N->T), $y:Fn(T->N)) -> Fn(T->T) = ~@($x,$y)")?;
         let mut context = ASTContext::from_tokens(tokens.clone());
         let node = parse_assign(&mut context)?;
         println!("{:?}", node);
@@ -671,12 +671,12 @@ mod tests {
             IJType::Function(FunctionSignature::new(
                 vec![
                     IJType::Function(FunctionSignature::new(
-                        vec![IJType::Scalar(None)],
+                        vec![IJType::Number(None)],
                         IJType::Tensor(None)
                     )),
                     IJType::Function(FunctionSignature::new(
                         vec![IJType::Tensor(None)],
-                        IJType::Scalar(None)
+                        IJType::Number(None)
                     ))
                 ],
                 IJType::Function(FunctionSignature::new(
@@ -695,7 +695,7 @@ mod tests {
         assert_eq!(
             node.operands[2].output_type,
             IJType::Function(FunctionSignature::new(
-                vec![IJType::Scalar(None)],
+                vec![IJType::Number(None)],
                 IJType::Tensor(None),
             ))
         );
@@ -703,7 +703,7 @@ mod tests {
             node.operands[3].output_type,
             IJType::Function(FunctionSignature::new(
                 vec![IJType::Tensor(None)],
-                IJType::Scalar(None),
+                IJType::Number(None),
             ))
         );
         Ok(())
@@ -715,24 +715,24 @@ mod tests {
         let mut context = ASTContext::from_tokens(tokens.clone());
         let assign_node = parse_assign(&mut context)?;
         let node0 = assign_node.operands[0].clone();
-        assert_eq!(node0.output_type, IJType::Group(vec![IJType::Scalar(None), IJType::Scalar(None)]));
+        assert_eq!(node0.output_type, IJType::Group(vec![IJType::Number(None), IJType::Number(None)]));
         assert_eq!(node0.op, Operation::Group);
         assert_eq!(node0.operands.len(), 2);
 
 
-        let tokens = lexer("(x: S<a>, y: S) = (1<a>,2<b>)")?;
+        let tokens = lexer("(x: N<a>, y: N) = (1<a>,2<b>)")?;
         let mut context = ASTContext::from_tokens(tokens.clone());
         let assign_node = parse_assign(&mut context)?;
         let node0 = assign_node.operands[0].clone();
-        assert_eq!(node0.output_type, IJType::Group(vec![IJType::Scalar(Some("a".to_string())), IJType::Scalar(Some("b".to_string()))]));
+        assert_eq!(node0.output_type, IJType::Group(vec![IJType::Number(Some("a".to_string())), IJType::Number(Some("b".to_string()))]));
         assert_eq!(node0.op, Operation::Group);
         assert_eq!(node0.operands.len(), 2);
 
-        let tokens = lexer("(x: S<a>, y: S) = (1<a>,2)")?;
+        let tokens = lexer("(x: N<a>, y: N) = (1<a>,2)")?;
         let mut context = ASTContext::from_tokens(tokens.clone());
         let assign_node = parse_assign(&mut context)?;
         let node0 = assign_node.operands[0].clone();
-        assert_eq!(node0.output_type, IJType::Group(vec![IJType::Scalar(Some("a".to_string())), IJType::Scalar(None)]));
+        assert_eq!(node0.output_type, IJType::Group(vec![IJType::Number(Some("a".to_string())), IJType::Number(None)]));
         assert_eq!(node0.op, Operation::Group);
         assert_eq!(node0.operands.len(), 2);
         Ok(())

--- a/ijzer/src/parser/binary_op.rs
+++ b/ijzer/src/parser/binary_op.rs
@@ -71,17 +71,6 @@ fn _next_node_functional_binary(
             context,
         )?));
     }
-    if check_ok_needed_outputs(needed_outputs, &IJType::Number(None)) {
-        let output_type = IJType::Number(None);
-        let input_type = vec![IJType::Number(None), IJType::Number(None)];
-        nodes.push(Rc::new(Node::new(
-            operation.clone(),
-            vec![],
-            IJType::Function(FunctionSignature::new(input_type, output_type)),
-            vec![],
-            context,
-        )?));
-    }
     if check_ok_needed_outputs(needed_outputs, &IJType::Tensor(None)) {
         let output_type = IJType::Tensor(None);
         let input_types = vec![

--- a/ijzer/src/parser/diag.rs
+++ b/ijzer/src/parser/diag.rs
@@ -84,7 +84,7 @@ mod tests {
         let (node, _) = parse_str_no_context("x = diag [1,2]")?;
         assert_eq!(node.op, Operation::Assign);
         let lhs = node.operands[0].clone();
-        assert_eq!(lhs.op, Operation::Symbol("x".to_string()));
+        assert_eq!(lhs.op, Operation::AssignSymbol("x".to_string()));
         let rhs = node.operands[1].clone();
         assert_eq!(rhs.op, Operation::Diag);
         Ok(())

--- a/ijzer/src/parser/generalized_contraction.rs
+++ b/ijzer/src/parser/generalized_contraction.rs
@@ -14,7 +14,7 @@ use std::rc::Rc;
 pub struct GeneralizedContraction;
 impl GeneralizedContraction {
     fn first_signature() -> FunctionSignature {
-        FunctionSignature::new(vec![IJType::Tensor(None)], IJType::Scalar(None))
+        FunctionSignature::new(vec![IJType::Tensor(None)], IJType::Number(None))
     }
     fn second_signature() -> FunctionSignature {
         FunctionSignature::number_function(2)

--- a/ijzer/src/parser/generalized_contraction.rs
+++ b/ijzer/src/parser/generalized_contraction.rs
@@ -180,7 +180,7 @@ mod tests {
     #[test]
     fn test_generalized_contraction_functions() -> Result<()> {
         let mut context = ASTContext::new();
-        parse_str("var f: Fn(T->S)", &mut context)?;
+        parse_str("var f: Fn(T->N)", &mut context)?;
         parse_str("var g: Fn(N,N->N)", &mut context)?;
         let node = parse_str("~? f g", &mut context)?;
         assert_eq!(node.op, Operation::GeneralizedContraction);
@@ -197,21 +197,21 @@ mod tests {
     #[test]
     fn test_generalized_contraction_functions_number_type() -> Result<()> {
         let mut context = ASTContext::new();
-        parse_str("var f: Fn(T->S)", &mut context)?;
+        parse_str("var f: Fn(T->N)", &mut context)?;
         parse_str("var g: Fn(N<f64>,N<f64>->N<f64>)", &mut context)?;
         let node = parse_str("? f g [1] [2]", &mut context)?;
         assert_eq!(node.op, Operation::GeneralizedContraction);
         assert_eq!(node.output_type, IJType::Tensor(Some("f64".to_string())));
 
         let mut context = ASTContext::new();
-        parse_str("var f: Fn(T<a>->S<b>)", &mut context)?;
+        parse_str("var f: Fn(T<a>->N<b>)", &mut context)?;
         parse_str("var g: Fn(N<a>,N<a>->N<a>)", &mut context)?;
         let node = parse_str("? f g [1]<a> [2]<a>", &mut context)?;
         assert_eq!(node.op, Operation::GeneralizedContraction);
         assert_eq!(node.output_type, IJType::Tensor(Some("b".to_string())));
 
         let mut context = ASTContext::new();
-        parse_str("var f: Fn(T<a>->S<b>)", &mut context)?;
+        parse_str("var f: Fn(T<a>->N<b>)", &mut context)?;
         parse_str("var g: Fn(N,N->N)", &mut context)?;
         let node = parse_str("? f g [1]<a> [2]<a>", &mut context)?;
         assert_eq!(node.op, Operation::GeneralizedContraction);
@@ -222,7 +222,7 @@ mod tests {
     #[test]
     fn test_generalized_contraction_functional_number_type() -> Result<()> {
         let mut context = ASTContext::new();
-        parse_str("var f: Fn(T->S)", &mut context)?;
+        parse_str("var f: Fn(T->N)", &mut context)?;
         parse_str("var g: Fn(N<f64>,N<f64>->N<f64>)", &mut context)?;
         let node = parse_str("~? f g", &mut context)?;
         assert_eq!(node.op, Operation::GeneralizedContraction);
@@ -238,7 +238,7 @@ mod tests {
         );
 
         let mut context = ASTContext::new();
-        parse_str("var f: Fn(T<f64>->S<f32>)", &mut context)?;
+        parse_str("var f: Fn(T<f64>->N<f32>)", &mut context)?;
         parse_str("var g: Fn(N<f64>,N<f64>->N<f64>)", &mut context)?;
         let node = parse_str("~? f g", &mut context)?;
         assert_eq!(node.op, Operation::GeneralizedContraction);
@@ -254,7 +254,7 @@ mod tests {
         );
 
         let mut context = ASTContext::new();
-        parse_str("var f: Fn(T<a>->S<b>)", &mut context)?;
+        parse_str("var f: Fn(T<a>->N<b>)", &mut context)?;
         parse_str("var g: Fn(N,N->N)", &mut context)?;
         let node = parse_str("~? f g", &mut context)?;
         assert_eq!(node.op, Operation::GeneralizedContraction);

--- a/ijzer/src/parser/identity.rs
+++ b/ijzer/src/parser/identity.rs
@@ -15,7 +15,7 @@ impl ParseNode for IdentityNode {
         context: &mut ASTContext,
     ) -> Result<(Rc<Node>, TokenSlice)> {
         let (operands, rest) = gather_operands(
-            vec![vec![IJType::Scalar(None)], vec![IJType::Tensor(None)]],
+            vec![vec![IJType::Number(None)], vec![IJType::Tensor(None)]],
             tokens,
             context,
         )?;
@@ -36,7 +36,7 @@ impl ParseNodeFunctional for IdentityNode {
         let slice = slice.move_start(1)?;
         let output_types = match needed_outputs {
             Some(outputs) => outputs,
-            None => &[IJType::Scalar(None), IJType::Tensor(None)],
+            None => &[IJType::Number(None), IJType::Tensor(None)],
         };
 
         let nodes = output_types
@@ -79,10 +79,10 @@ mod tests {
 
     #[test]
     fn test_identity_functional() -> Result<()> {
-        let (node, _) = parse_str_no_context("~I: Fn(S->S)")?;
+        let (node, _) = parse_str_no_context("~I: Fn(N->N)")?;
         assert_eq!(node.op, Operation::Identity);
         assert_eq!(node.input_types.len(), 0);
-        assert_eq!(node.output_type, IJType::scalar_function(1));
+        assert_eq!(node.output_type, IJType::number_function(1));
         let (node, _) = parse_str_no_context("~I: Fn(T->T)")?;
         assert_eq!(node.op, Operation::Identity);
         assert_eq!(node.input_types.len(), 0);
@@ -97,13 +97,13 @@ mod tests {
     #[test]
     fn test_identity_number_type() -> Result<()> {
         let (node, _) = parse_str_no_context("I 1<a>")?;
-        assert_eq!(node.output_type, IJType::Scalar(Some("a".to_string())));
+        assert_eq!(node.output_type, IJType::Number(Some("a".to_string())));
 
         let (node, _) = parse_str_no_context("I [1]<a>")?;
         assert_eq!(node.output_type, IJType::Tensor(Some("a".to_string())));
 
         let (node, _) = parse_str_no_context("I I I I I 1<a>")?;
-        assert_eq!(node.output_type, IJType::Scalar(Some("a".to_string())));
+        assert_eq!(node.output_type, IJType::Number(Some("a".to_string())));
 
         Ok(())
     }

--- a/ijzer/src/parser/index.rs
+++ b/ijzer/src/parser/index.rs
@@ -53,7 +53,7 @@ impl ParseNode for Index {
             } else {
                 let (node, _) = gather_operands(
                     vec![
-                        vec![IJType::Scalar(Some("usize".to_string()))],
+                        vec![IJType::Number(Some("usize".to_string()))],
                         vec![IJType::Tensor(Some("usize".to_string()))],
                     ],
                     operand_slice,
@@ -64,7 +64,7 @@ impl ParseNode for Index {
         }
         let is_all_numbers = index_operands.iter().all(|n| {
             n.output_type
-                .type_match(&IJType::Scalar(Some("usize".to_string())))
+                .type_match(&IJType::Number(Some("usize".to_string())))
         });
         let contains_colon = index_operands
             .iter()
@@ -81,7 +81,7 @@ impl ParseNode for Index {
             Rc::new(Node::new(
                 Operation::Index,
                 all_operands.iter().map(|n| n.output_type.clone()).collect(),
-                IJType::Scalar(
+                IJType::Number(
                     tensor_operand
                         .output_type
                         .extract_number_type()
@@ -116,11 +116,11 @@ mod tests {
             node.input_types,
             vec![
                 IJType::Tensor(None),
-                IJType::Scalar(None),
-                IJType::Scalar(None)
+                IJType::Number(None),
+                IJType::Number(None)
             ]
         );
-        assert_eq!(node.output_type, IJType::Scalar(None));
+        assert_eq!(node.output_type, IJType::Number(None));
         Ok(())
     }
 
@@ -130,7 +130,7 @@ mod tests {
         assert_eq!(node.op, Operation::Index);
         assert_eq!(
             node.input_types,
-            vec![IJType::Tensor(None), IJType::Scalar(None), IJType::Void]
+            vec![IJType::Tensor(None), IJType::Number(None), IJType::Void]
         );
         assert_eq!(node.output_type, IJType::Tensor(None));
         Ok(())
@@ -144,7 +144,7 @@ mod tests {
             node.input_types,
             vec![
                 IJType::Tensor(None),
-                IJType::Scalar(None),
+                IJType::Number(None),
                 IJType::Tensor(None)
             ]
         );
@@ -167,11 +167,11 @@ mod tests {
             node.input_types,
             vec![
                 IJType::Tensor(Some("i64".to_string())),
-                IJType::Scalar(Some("usize".to_string())),
-                IJType::Scalar(Some("usize".to_string()))
+                IJType::Number(Some("usize".to_string())),
+                IJType::Number(Some("usize".to_string()))
             ]
         );
-        assert_eq!(node.output_type, IJType::Scalar(Some("i64".to_string())));
+        assert_eq!(node.output_type, IJType::Number(Some("i64".to_string())));
         Ok(())
     }
 }

--- a/ijzer/src/parser/index.rs
+++ b/ijzer/src/parser/index.rs
@@ -21,7 +21,6 @@ impl ParseNode for Index {
 
         let next_token = context.get_token_at_index(rest.start)?;
         let rest = rest.move_start(1)?;
-        println!("next_token: {:?}", next_token);
         if !matches!(next_token, Token::LSqBracket) {
             return Err(context.add_context_to_syntax_error(
                 SyntaxError::ExpectedLSqBracketAfterIndex.into(),

--- a/ijzer/src/parser/minus.rs
+++ b/ijzer/src/parser/minus.rs
@@ -20,11 +20,11 @@ impl ParseNode for MinusOp {
         // let two_tensors = vec![IJType::Tensor; 2];
         let allowed_types = vec![
             vec![IJType::Tensor(None)],
-            vec![IJType::Scalar(None)],
+            vec![IJType::Number(None)],
             vec![IJType::Tensor(None), IJType::Tensor(None)],
-            vec![IJType::Scalar(None), IJType::Scalar(None)],
-            vec![IJType::Tensor(None), IJType::Scalar(None)],
-            vec![IJType::Scalar(None), IJType::Tensor(None)],
+            vec![IJType::Number(None), IJType::Number(None)],
+            vec![IJType::Tensor(None), IJType::Number(None)],
+            vec![IJType::Number(None), IJType::Tensor(None)],
         ];
         let (operands, rest) = gather_operands(allowed_types, slice, context)?;
         let input_types = operands
@@ -33,9 +33,9 @@ impl ParseNode for MinusOp {
             .collect::<Vec<IJType>>();
         let output_type = if input_types
             .iter()
-            .all(|t| t.type_match(&IJType::Scalar(None)))
+            .all(|t| t.type_match(&IJType::Number(None)))
         {
-            IJType::Scalar(None)
+            IJType::Number(None)
         } else if input_types
             .iter()
             .any(|t| t.type_match(&IJType::Tensor(None)))
@@ -104,18 +104,18 @@ impl ParseNodeFunctional for MinusOp {
     ) -> Result<(Vec<Rc<Node>>, TokenSlice)> {
         let rest = slice.move_start(1)?;
         let mut nodes = vec![];
-        if check_ok_needed_outputs(needed_output, &IJType::Scalar(None)) {
+        if check_ok_needed_outputs(needed_output, &IJType::Number(None)) {
             nodes.push(Rc::new(Node::new(
                 Operation::Subtract,
                 vec![],
-                IJType::scalar_function(2),
+                IJType::number_function(2),
                 vec![],
                 context,
             )?));
             nodes.push(Rc::new(Node::new(
                 Operation::Negate,
                 vec![],
-                IJType::scalar_function(1),
+                IJType::number_function(1),
                 vec![],
                 context,
             )?));
@@ -140,8 +140,8 @@ impl ParseNodeFunctional for MinusOp {
             let output_type = IJType::Tensor(None);
             let input_types = vec![
                 vec![IJType::Tensor(None), IJType::Tensor(None)],
-                vec![IJType::Scalar(None), IJType::Tensor(None)],
-                vec![IJType::Tensor(None), IJType::Scalar(None)],
+                vec![IJType::Number(None), IJType::Tensor(None)],
+                vec![IJType::Tensor(None), IJType::Number(None)],
                 vec![IJType::Tensor(None)],
             ];
             for input_type in input_types {
@@ -189,7 +189,7 @@ mod tests {
             })
         );
         assert_eq!(node.input_types, vec![]);
-        assert_eq!(node.output_type, IJType::Scalar(None));
+        assert_eq!(node.output_type, IJType::Number(None));
     }
     #[test]
     fn test_double_negate_with_scalar() {
@@ -203,7 +203,7 @@ mod tests {
             })
         );
         assert_eq!(node.input_types, vec![]);
-        assert_eq!(node.output_type, IJType::Scalar(None));
+        assert_eq!(node.output_type, IJType::Number(None));
     }
 
     #[test]
@@ -237,7 +237,7 @@ mod tests {
         assert_eq!(node.op, Operation::Subtract);
         assert_eq!(
             node.input_types,
-            vec![IJType::Tensor(None), IJType::Scalar(None)]
+            vec![IJType::Tensor(None), IJType::Number(None)]
         );
         assert_eq!(node.output_type, IJType::Tensor(None));
     }
@@ -250,9 +250,9 @@ mod tests {
         assert_eq!(node.op, Operation::Subtract);
         assert_eq!(
             node.input_types,
-            vec![IJType::Scalar(None), IJType::Scalar(None)]
+            vec![IJType::Number(None), IJType::Number(None)]
         );
-        assert_eq!(node.output_type, IJType::Scalar(None));
+        assert_eq!(node.output_type, IJType::Number(None));
     }
 
     #[test]
@@ -269,28 +269,28 @@ mod tests {
         assert_eq!(node.op, Operation::Subtract);
         assert_eq!(
             node.input_types,
-            vec![IJType::Scalar(Some("a".to_string())), IJType::Scalar(None)]
+            vec![IJType::Number(Some("a".to_string())), IJType::Number(None)]
         );
-        assert_eq!(node.output_type, IJType::Scalar(Some("a".to_string())));
+        assert_eq!(node.output_type, IJType::Number(Some("a".to_string())));
 
         let (node, _) = parse_str_no_context("- 1 2<a>")?;
         assert_eq!(node.op, Operation::Subtract);
         assert_eq!(
             node.input_types,
-            vec![IJType::Scalar(None), IJType::Scalar(Some("a".to_string()))]
+            vec![IJType::Number(None), IJType::Number(Some("a".to_string()))]
         );
-        assert_eq!(node.output_type, IJType::Scalar(Some("a".to_string())));
+        assert_eq!(node.output_type, IJType::Number(Some("a".to_string())));
 
         let (node, _) = parse_str_no_context("- 1<a> 2<a>")?;
         assert_eq!(node.op, Operation::Subtract);
         assert_eq!(
             node.input_types,
             vec![
-                IJType::Scalar(Some("a".to_string())),
-                IJType::Scalar(Some("a".to_string()))
+                IJType::Number(Some("a".to_string())),
+                IJType::Number(Some("a".to_string()))
             ]
         );
-        assert_eq!(node.output_type, IJType::Scalar(Some("a".to_string())));
+        assert_eq!(node.output_type, IJType::Number(Some("a".to_string())));
 
         let result = parse_str_no_context("- 1<a> 2<b>");
         assert!(result.is_err());

--- a/ijzer/src/parser/minus.rs
+++ b/ijzer/src/parser/minus.rs
@@ -120,22 +120,7 @@ impl ParseNodeFunctional for MinusOp {
                 context,
             )?));
         }
-        if check_ok_needed_outputs(needed_output, &IJType::Number(None)) {
-            nodes.push(Rc::new(Node::new(
-                Operation::Subtract,
-                vec![],
-                IJType::number_function(2),
-                vec![],
-                context,
-            )?));
-            nodes.push(Rc::new(Node::new(
-                Operation::Negate,
-                vec![],
-                IJType::number_function(1),
-                vec![],
-                context,
-            )?));
-        }
+
         if check_ok_needed_outputs(needed_output, &IJType::Tensor(None)) {
             let output_type = IJType::Tensor(None);
             let input_types = vec![

--- a/ijzer/src/parser/mod.rs
+++ b/ijzer/src/parser/mod.rs
@@ -289,18 +289,18 @@ mod tests {
     }
 
     #[test]
-    fn test_scalar_assignment() {
-        let result = parse_str_no_context("x: S = 1");
+    fn test_number_assignment() {
+        let result = parse_str_no_context("x: N = 1");
         assert!(result.is_ok());
         let (node, context) = result.unwrap();
         assert_eq!(node.op, Operation::Assign);
-        assert_eq!(node.input_types, vec![IJType::Scalar(None); 2]);
+        assert_eq!(node.input_types, vec![IJType::Number(None); 2]);
         assert_eq!(node.output_type, IJType::Void);
         let first_operand = &node.operands[0];
         assert_eq!(first_operand.op, Operation::Symbol("x".to_string()));
-        assert_eq!(first_operand.output_type, IJType::Scalar(None));
+        assert_eq!(first_operand.output_type, IJType::Number(None));
         let second_operand = &node.operands[1];
-        assert_eq!(second_operand.output_type, IJType::Scalar(None));
+        assert_eq!(second_operand.output_type, IJType::Number(None));
         assert_eq!(
             second_operand.op,
             Operation::Number(tokens::Number {
@@ -309,7 +309,7 @@ mod tests {
         );
 
         let expected_var = Variable {
-            typ: IJType::Scalar(None),
+            typ: IJType::Number(None),
             name: "x".to_string(),
         };
         let actual_var = context.symbols.get("x").unwrap();
@@ -376,7 +376,7 @@ mod tests {
         assert!(result.is_ok());
         let node = result.unwrap();
         assert_eq!(node.op, Operation::Function("x".to_string()));
-        assert_eq!(node.input_types, vec![IJType::Scalar(None)]);
+        assert_eq!(node.input_types, vec![IJType::Number(None)]);
         assert_eq!(node.output_type, IJType::Tensor(None));
     }
 
@@ -398,8 +398,8 @@ mod tests {
         assert!(result.is_ok());
         let (node, _) = result.unwrap();
         assert_eq!(node.op, Operation::Negate);
-        assert_eq!(node.input_types, vec![IJType::Scalar(None)]);
-        assert_eq!(node.output_type, IJType::Scalar(None));
+        assert_eq!(node.input_types, vec![IJType::Number(None)]);
+        assert_eq!(node.output_type, IJType::Number(None));
     }
 
     #[test]
@@ -436,7 +436,7 @@ mod tests {
         let node = parse_str("f [1]", &mut context)?;
         assert_eq!(
             node.output_type,
-            IJType::Group(vec![IJType::Scalar(None), IJType::Tensor(None)])
+            IJType::Group(vec![IJType::Number(None), IJType::Tensor(None)])
         );
 
         let mut context = ASTContext::new();
@@ -446,12 +446,12 @@ mod tests {
         let node0 = &node.operands[0];
         assert_eq!(
             node0.output_type,
-            IJType::Group(vec![IJType::Scalar(None), IJType::Tensor(None)])
+            IJType::Group(vec![IJType::Number(None), IJType::Tensor(None)])
         );
         let node1 = &node.operands[1];
         assert_eq!(
             node1.output_type,
-            IJType::Group(vec![IJType::Scalar(None), IJType::Tensor(None)])
+            IJType::Group(vec![IJType::Number(None), IJType::Tensor(None)])
         );
 
         Ok(())

--- a/ijzer/src/parser/mod.rs
+++ b/ijzer/src/parser/mod.rs
@@ -274,7 +274,7 @@ mod tests {
         assert_eq!(node.input_types, vec![IJType::Tensor(None); 2]);
         assert_eq!(node.output_type, IJType::Void);
         let first_operand = &node.operands[0];
-        assert_eq!(first_operand.op, Operation::Symbol("x".to_string()));
+        assert_eq!(first_operand.op, Operation::AssignSymbol("x".to_string()));
         assert_eq!(first_operand.output_type, IJType::Tensor(None));
         let second_operand = &node.operands[1];
         assert_eq!(second_operand.output_type, IJType::Tensor(None));
@@ -297,7 +297,7 @@ mod tests {
         assert_eq!(node.input_types, vec![IJType::Number(None); 2]);
         assert_eq!(node.output_type, IJType::Void);
         let first_operand = &node.operands[0];
-        assert_eq!(first_operand.op, Operation::Symbol("x".to_string()));
+        assert_eq!(first_operand.op, Operation::AssignSymbol("x".to_string()));
         assert_eq!(first_operand.output_type, IJType::Number(None));
         let second_operand = &node.operands[1];
         assert_eq!(second_operand.output_type, IJType::Number(None));
@@ -338,7 +338,7 @@ mod tests {
         );
         assert_eq!(node.output_type, IJType::Void);
         let first_operand = &node.operands[0];
-        assert_eq!(first_operand.op, Operation::Symbol("x".to_string()));
+        assert_eq!(first_operand.op, Operation::AssignSymbol("x".to_string()));
 
         assert_eq!(
             first_operand.output_type,

--- a/ijzer/src/parser/mod.rs
+++ b/ijzer/src/parser/mod.rs
@@ -371,7 +371,7 @@ mod tests {
     #[test]
     fn test_var_definition_and_use() {
         let mut context = ASTContext::new();
-        parse_str("var x: Fn(S->T)", &mut context).unwrap();
+        parse_str("var x: Fn(N->T)", &mut context).unwrap();
         let result = parse_str("x 1", &mut context);
         assert!(result.is_ok());
         let node = result.unwrap();
@@ -405,11 +405,11 @@ mod tests {
     #[test]
     fn test_semicolon_handling() {
         // Test with semicolon at the end - should pass
-        let result_with_semicolon = parse_str_no_context("var x: S;");
+        let result_with_semicolon = parse_str_no_context("var x: N;");
         assert!(result_with_semicolon.is_ok());
 
         // Test without semicolon at the end - should also pass and be equivalent
-        let result_without_semicolon = parse_str_no_context("var x: S");
+        let result_without_semicolon = parse_str_no_context("var x: N");
         assert!(result_without_semicolon.is_ok());
 
         // Compare the results to ensure they are equivalent
@@ -421,7 +421,7 @@ mod tests {
         );
 
         // Test with semicolon not at the end - should fail
-        let result_error = parse_str_no_context("var x: S; var y: T");
+        let result_error = parse_str_no_context("var x: N; var y: T");
         assert!(result_error.is_err());
         assert!(is_specific_syntax_error(
             &result_error.unwrap_err(),
@@ -432,7 +432,7 @@ mod tests {
     #[test]
     fn test_group_return_type() -> Result<()> {
         let mut context = ASTContext::new();
-        parse_str("var f: Fn(T->(S,T))", &mut context)?;
+        parse_str("var f: Fn(T->(N,T))", &mut context)?;
         let node = parse_str("f [1]", &mut context)?;
         assert_eq!(
             node.output_type,
@@ -440,7 +440,7 @@ mod tests {
         );
 
         let mut context = ASTContext::new();
-        parse_str("var f: Fn(T->(S,T))", &mut context)?;
+        parse_str("var f: Fn(T->(N,T))", &mut context)?;
         let node = parse_str("x = f[1]", &mut context)?;
         assert_eq!(node.op, Operation::Assign);
         let node0 = &node.operands[0];

--- a/ijzer/src/parser/number.rs
+++ b/ijzer/src/parser/number.rs
@@ -25,7 +25,7 @@ impl ParseNode for NumberNode {
                     Rc::new(Node::new(
                         node_op,
                         vec![],
-                        IJType::Scalar(Some(n.clone())),
+                        IJType::Number(Some(n.clone())),
                         vec![],
                         context,
                     )?),
@@ -36,7 +36,7 @@ impl ParseNode for NumberNode {
                 Rc::new(Node::new(
                     node_op,
                     vec![],
-                    IJType::Scalar(None),
+                    IJType::Number(None),
                     vec![],
                     context,
                 )?),
@@ -61,7 +61,7 @@ mod tests {
                 value: "1.0".to_string()
             })
         );
-        assert_eq!(node.output_type, IJType::Scalar(None));
+        assert_eq!(node.output_type, IJType::Number(None));
         let (node, _) = parse_str_no_context("1")?;
         assert_eq!(
             node.op,
@@ -69,7 +69,7 @@ mod tests {
                 value: "1".to_string()
             })
         );
-        assert_eq!(node.output_type, IJType::Scalar(None));
+        assert_eq!(node.output_type, IJType::Number(None));
         Ok(())
     }
 
@@ -82,7 +82,7 @@ mod tests {
                 value: "1.0".to_string()
             })
         );
-        assert_eq!(node.output_type, IJType::Scalar(Some("_".to_string())));
+        assert_eq!(node.output_type, IJType::Number(Some("_".to_string())));
         let (node, _) = parse_str_no_context("1.0<f64>")?;
         assert_eq!(
             node.op,
@@ -90,7 +90,7 @@ mod tests {
                 value: "1.0".to_string()
             })
         );
-        assert_eq!(node.output_type, IJType::Scalar(Some("f64".to_string())));
+        assert_eq!(node.output_type, IJType::Number(Some("f64".to_string())));
         let (node, _) = parse_str_no_context("1<i32>")?;
         assert_eq!(
             node.op,
@@ -98,7 +98,7 @@ mod tests {
                 value: "1".to_string()
             })
         );
-        assert_eq!(node.output_type, IJType::Scalar(Some("i32".to_string())));
+        assert_eq!(node.output_type, IJType::Number(Some("i32".to_string())));
         Ok(())
     }
 }

--- a/ijzer/src/parser/parser_functions.rs
+++ b/ijzer/src/parser/parser_functions.rs
@@ -139,12 +139,12 @@ mod tests {
 
     #[test]
     fn test_variable_declaration_scalar() {
-        let result = parse_str_no_context("var b: S");
+        let result = parse_str_no_context("var b: N");
         assert!(result.is_ok());
         let (node, context) = result.unwrap();
         assert_eq!(node.op, Operation::Nothing);
         let expected_var = Variable {
-            typ: IJType::Scalar(None),
+            typ: IJType::Number(None),
             name: "b".to_string(),
         };
         let actual_var = context.symbols.get("b").unwrap();
@@ -167,13 +167,13 @@ mod tests {
 
     #[test]
     fn test_function_declaration_scalar_to_tensor() {
-        let result = parse_str_no_context("var scale: Fn(S -> T)");
+        let result = parse_str_no_context("var scale: Fn(N -> T)");
         assert!(result.is_ok());
         let (node, context) = result.unwrap();
         assert_eq!(node.op, Operation::Nothing);
         let expected_var = Variable {
             typ: IJType::Function(FunctionSignature::new(
-                vec![IJType::Scalar(None)],
+                vec![IJType::Number(None)],
                 IJType::Tensor(None),
             )),
             name: "scale".to_string(),

--- a/ijzer/src/parser/reduction.rs
+++ b/ijzer/src/parser/reduction.rs
@@ -31,7 +31,7 @@ impl ParseNode for Reduction {
             Rc::new(Node::new(
                 Operation::Reduce,
                 vec![function.output_type.clone(), operand.output_type.clone()],
-                IJType::Scalar(output_number_type),
+                IJType::Number(output_number_type),
                 vec![function, operand],
                 context,
             )?),
@@ -46,7 +46,7 @@ impl ParseNodeFunctional for Reduction {
         context: &mut ASTContext,
         needed_outputs: Option<&[IJType]>,
     ) -> Result<(Vec<Rc<Node>>, TokenSlice)> {
-        let actual_outputs = IJType::Scalar(None);
+        let actual_outputs = IJType::Number(None);
         if !check_ok_needed_outputs(needed_outputs, &actual_outputs) {
             return Err(SyntaxError::FunctionSignatureMismatch(
                 format!("{:?}", needed_outputs),
@@ -67,7 +67,7 @@ impl ParseNodeFunctional for Reduction {
             vec![function.output_type.clone()],
             IJType::Function(FunctionSignature::new(
                 vec![IJType::Tensor(input_number_type)],
-                IJType::Scalar(output_number_type),
+                IJType::Number(output_number_type),
             )),
             vec![function],
             context,
@@ -92,7 +92,7 @@ mod tests {
             node.input_types,
             vec![IJType::number_function(2), IJType::Tensor(None)]
         );
-        assert_eq!(node.output_type, IJType::Scalar(None));
+        assert_eq!(node.output_type, IJType::Number(None));
     }
 
     #[test]
@@ -108,7 +108,7 @@ mod tests {
             node.input_types,
             vec![IJType::number_function(2), IJType::Tensor(None)]
         );
-        assert_eq!(node.output_type, IJType::Scalar(None));
+        assert_eq!(node.output_type, IJType::Number(None));
     }
 
     #[test]
@@ -118,7 +118,7 @@ mod tests {
             Token::Reduction,
             slice,
             &mut context,
-            Some(&[IJType::Scalar(None)]),
+            Some(&[IJType::Number(None)]),
         )?;
         println!("{:?}", result);
         Ok(())
@@ -130,13 +130,13 @@ mod tests {
         parse_str("var f: Fn(N<a>,N<a>->N<a>)", &mut context)?;
         let node = parse_str("/f [1,2]<a>", &mut context)?;
         assert_eq!(node.op, Operation::Reduce);
-        assert_eq!(node.output_type, IJType::Scalar(Some("a".to_string())));
+        assert_eq!(node.output_type, IJType::Number(Some("a".to_string())));
 
         let mut context = ASTContext::new();
         parse_str("var f: Fn(N<a>,N<a>->N<b>)", &mut context)?;
         let node = parse_str("/f [1,2]<a>", &mut context)?;
         assert_eq!(node.op, Operation::Reduce);
-        assert_eq!(node.output_type, IJType::Scalar(Some("b".to_string())));
+        assert_eq!(node.output_type, IJType::Number(Some("b".to_string())));
         Ok(())
     }
 
@@ -150,7 +150,7 @@ mod tests {
             node.output_type,
             IJType::Function(FunctionSignature::new(
                 vec![IJType::Tensor(Some("a".to_string()))],
-                IJType::Scalar(Some("a".to_string()))
+                IJType::Number(Some("a".to_string()))
             ))
         );
 
@@ -162,7 +162,7 @@ mod tests {
             node.output_type,
             IJType::Function(FunctionSignature::new(
                 vec![IJType::Tensor(Some("a".to_string()))],
-                IJType::Scalar(Some("b".to_string()))
+                IJType::Number(Some("b".to_string()))
             ))
         );
         Ok(())
@@ -172,7 +172,7 @@ mod tests {
     fn test_with_composition() -> Result<()> {
         let (node, _) = parse_str_no_context("@(/+, -, +) [1,2] [3,4]")?;
         assert_eq!(node.op, Operation::FunctionComposition(3));
-        assert_eq!(node.output_type, IJType::Scalar(None));
+        assert_eq!(node.output_type, IJType::Number(None));
         Ok(())
     }
 }

--- a/ijzer/src/parser/symbol.rs
+++ b/ijzer/src/parser/symbol.rs
@@ -53,16 +53,6 @@ impl ParseNode for Symbol {
                     )?,
                     slice,
                 ),
-                IJType::Number(n) => (
-                    Node::new(
-                        Operation::Symbol(name.clone()),
-                        vec![],
-                        IJType::Number(n),
-                        vec![],
-                        context,
-                    )?,
-                    slice,
-                ),
                 _ => unreachable!(),
             };
             Ok((Rc::new(node), rest))

--- a/ijzer/src/parser/symbol.rs
+++ b/ijzer/src/parser/symbol.rs
@@ -43,11 +43,11 @@ impl ParseNode for Symbol {
                     )?;
                     (node, rest)
                 }
-                IJType::Scalar(n) => (
+                IJType::Number(n) => (
                     Node::new(
                         Operation::Symbol(name.clone()),
                         vec![],
-                        IJType::Scalar(n),
+                        IJType::Number(n),
                         vec![],
                         context,
                     )?,
@@ -132,17 +132,17 @@ mod tests {
         assert_eq!(node.output_type, IJType::Tensor(Some("a".to_string())));
 
         let mut context = ASTContext::new();
-        parse_str("var x: S<a>", &mut context)?;
+        parse_str("var x: N<a>", &mut context)?;
         let node = parse_str("x", &mut context)?;
-        assert_eq!(node.output_type, IJType::Scalar(Some("a".to_string())));
+        assert_eq!(node.output_type, IJType::Number(Some("a".to_string())));
 
         let mut context = ASTContext::new();
-        parse_str("var x: Fn(S<a>->T<a>)", &mut context)?;
+        parse_str("var x: Fn(N<a>->T<a>)", &mut context)?;
         let node = parse_str("~x", &mut context)?;
         assert_eq!(
             node.output_type,
             IJType::Function(FunctionSignature::new(
-                vec![IJType::Scalar(Some("a".to_string()))],
+                vec![IJType::Number(Some("a".to_string()))],
                 IJType::Tensor(Some("a".to_string())),
             ))
         );

--- a/ijzer/src/parser/type_conversion.rs
+++ b/ijzer/src/parser/type_conversion.rs
@@ -208,13 +208,13 @@ mod tests {
     #[test]
     fn test_list_conversions_to() {
         let types = list_conversions_to(&IJType::Number(None));
-        assert_eq!(types.len(), 3);
+        assert_eq!(types.len(), 2);
 
         let types = list_conversions_to(&IJType::Function(FunctionSignature::new(
             vec![IJType::Number(None)],
             IJType::Number(None),
         )));
-        assert_eq!(types.len(), 6);
+        assert_eq!(types.len(), 2);
 
         let types = list_conversions_to(&IJType::Function(FunctionSignature::new(
             vec![IJType::Tensor(None)],
@@ -223,19 +223,19 @@ mod tests {
                 IJType::Number(None),
             )),
         )));
-        assert_eq!(types.len(), 18);
+        assert_eq!(types.len(), 4);
     }
 
     #[test]
     fn test_list_conversions_from() {
         let types = list_conversions_from(&IJType::Number(None));
-        assert_eq!(types.len(), 2);
+        assert_eq!(types.len(), 1);
 
         let types = list_conversions_from(&IJType::Function(FunctionSignature::new(
             vec![IJType::Number(None)],
             IJType::Number(None),
         )));
-        assert_eq!(types.len(), 6);
+        assert_eq!(types.len(), 2);
 
         let types = list_conversions_from(&IJType::Function(FunctionSignature::new(
             vec![IJType::Tensor(None)],
@@ -244,7 +244,7 @@ mod tests {
                 IJType::Number(None),
             )),
         )));
-        assert_eq!(types.len(), 6);
+        assert_eq!(types.len(), 2);
     }
 
     #[test]
@@ -301,9 +301,9 @@ mod tests {
     #[test]
     fn test_type_conversion_node_function2() {
         let mut context = ASTContext::new();
-        let result = parse_str("var f: Fn(S->S)", &mut context);
+        let result = parse_str("var f: Fn(T->N)", &mut context);
         assert!(result.is_ok());
-        let maybe_node = parse_str("<-Fn(S->S) f 1", &mut context);
+        let maybe_node = parse_str("<-Fn(N->N) f 1", &mut context);
         assert!(maybe_node.is_ok());
         let node = maybe_node.unwrap();
         assert_eq!(node.op, Operation::Apply);
@@ -314,7 +314,7 @@ mod tests {
         let mut context = ASTContext::new();
         let result = parse_str("var f: Fn(T->T)", &mut context);
         assert!(result.is_ok());
-        let maybe_node = parse_str("<-Fn(S->T) f 1", &mut context);
+        let maybe_node = parse_str("<-Fn(N->T) f 1", &mut context);
         assert!(maybe_node.is_ok());
         let node = maybe_node.unwrap();
         assert_eq!(node.op, Operation::Apply);
@@ -326,14 +326,14 @@ mod tests {
         let mut context = ASTContext::new();
         let result = parse_str("var f: Fn(T->T)", &mut context);
         assert!(result.is_ok());
-        let maybe_node = parse_str("<-Fn(T->S) f [1]", &mut context);
+        let maybe_node = parse_str("<-Fn(T->N) f [1]", &mut context);
         assert!(maybe_node.is_err());
     }
 
     #[test]
     fn test_type_conversion_functional() {
         let mut context = ASTContext::new();
-        let result = parse_str("var f: Fn(S,S->S)", &mut context);
+        let result = parse_str("var f: Fn(T,T->N)", &mut context);
         assert!(result.is_ok());
         let maybe_node = parse_str("/<-Fn(N,N->N) f [1]", &mut context);
         assert!(maybe_node.is_ok());

--- a/ijzer/src/parser/type_conversion.rs
+++ b/ijzer/src/parser/type_conversion.rs
@@ -15,11 +15,7 @@ use std::rc::Rc;
 /// List all possible types a type can be converted to
 fn list_conversions_to(from: &IJType) -> Vec<IJType> {
     match from {
-        IJType::Number(n) | IJType::Scalar(n) => vec![
-            IJType::Number(n.clone()),
-            IJType::Scalar(n.clone()),
-            IJType::Tensor(n.clone()),
-        ],
+        IJType::Number(n) => vec![IJType::Number(n.clone()), IJType::Tensor(n.clone())],
         IJType::Function(signature) => {
             let input_conversions: Vec<Vec<IJType>> = signature
                 .input
@@ -45,14 +41,10 @@ fn list_conversions_to(from: &IJType) -> Vec<IJType> {
 /// list all possible conversions a type could have been converted from
 fn list_conversions_from(to: &IJType) -> Vec<IJType> {
     match to {
-        IJType::Number(n) | IJType::Scalar(n) => {
-            vec![IJType::Number(n.clone()), IJType::Scalar(n.clone())]
+        IJType::Number(n) => {
+            vec![IJType::Number(n.clone())]
         }
-        IJType::Tensor(n) => vec![
-            IJType::Tensor(n.clone()),
-            IJType::Number(n.clone()),
-            IJType::Scalar(n.clone()),
-        ],
+        IJType::Tensor(n) => vec![IJType::Tensor(n.clone()), IJType::Number(n.clone())],
         IJType::Function(signature) => {
             let input_conversions: Vec<Vec<IJType>> = signature
                 .input
@@ -123,7 +115,7 @@ impl ParseNode for TypeConversion {
         let rest = slice.move_start(type_end)?;
 
         match desired_type {
-            IJType::Scalar(_) | IJType::Tensor(_) | IJType::Number(_) => {
+            IJType::Tensor(_) | IJType::Number(_) => {
                 let (operand, rest) = next_node(rest, context)?;
                 let possible_conversions = list_conversions_from(&desired_type);
                 let current_type = operand.output_type.clone();
@@ -220,7 +212,7 @@ mod tests {
 
         let types = list_conversions_to(&IJType::Function(FunctionSignature::new(
             vec![IJType::Number(None)],
-            IJType::Scalar(None),
+            IJType::Number(None),
         )));
         assert_eq!(types.len(), 6);
 
@@ -228,7 +220,7 @@ mod tests {
             vec![IJType::Tensor(None)],
             IJType::Function(FunctionSignature::new(
                 vec![IJType::Number(None)],
-                IJType::Scalar(None),
+                IJType::Number(None),
             )),
         )));
         assert_eq!(types.len(), 18);
@@ -241,7 +233,7 @@ mod tests {
 
         let types = list_conversions_from(&IJType::Function(FunctionSignature::new(
             vec![IJType::Number(None)],
-            IJType::Scalar(None),
+            IJType::Number(None),
         )));
         assert_eq!(types.len(), 6);
 
@@ -249,7 +241,7 @@ mod tests {
             vec![IJType::Tensor(None)],
             IJType::Function(FunctionSignature::new(
                 vec![IJType::Number(None)],
-                IJType::Scalar(None),
+                IJType::Number(None),
             )),
         )));
         assert_eq!(types.len(), 6);
@@ -262,7 +254,7 @@ mod tests {
         let slice = context.full_slice();
         let desired_signature = FunctionSignature::new(
             vec![IJType::Number(None), IJType::Number(None)],
-            IJType::Scalar(None),
+            IJType::Number(None),
         );
         let maybe_nodes = type_conversion_functional_part(slice, &mut context, desired_signature);
         assert!(maybe_nodes.is_ok());
@@ -276,7 +268,7 @@ mod tests {
         let slice = context.full_slice();
         let desired_signature = FunctionSignature::new(
             vec![IJType::Tensor(None), IJType::Tensor(None)],
-            IJType::Scalar(None),
+            IJType::Number(None),
         );
         let maybe_nodes = type_conversion_functional_part(slice, &mut context, desired_signature);
         assert!(maybe_nodes.is_err());
@@ -294,13 +286,13 @@ mod tests {
         let (node, _) = result.unwrap();
         assert_eq!(node.op, Operation::TypeConversion);
 
-        let result = parse_str_no_context("<-S [1.0]");
+        let result = parse_str_no_context("<-N [1.0]");
         assert!(result.is_err());
     }
 
     #[test]
     fn test_type_conversion_node_function1() {
-        let result = parse_str_no_context("<-Fn(S,S->T) + 1 1");
+        let result = parse_str_no_context("<-Fn(N,N->T) + 1 1");
         assert!(result.is_ok());
         let (node, _) = result.unwrap();
         assert_eq!(node.op, Operation::Apply);
@@ -353,19 +345,19 @@ mod tests {
     #[test]
     fn test_type_conversion_number_type() -> Result<()> {
         let mut context = ASTContext::new();
-        parse_str("var x: S<a>", &mut context)?;
+        parse_str("var x: N<a>", &mut context)?;
         let node = parse_str("<-N<a> x", &mut context)?;
         assert_eq!(node.op, Operation::TypeConversion);
         assert_eq!(node.output_type, IJType::Number(Some("a".to_string())));
 
         let mut context = ASTContext::new();
         parse_str("var x: N<a>", &mut context)?;
-        let node = parse_str("<-S<a> x", &mut context)?;
+        let node = parse_str("<-N<a> x", &mut context)?;
         assert_eq!(node.op, Operation::TypeConversion);
-        assert_eq!(node.output_type, IJType::Scalar(Some("a".to_string())));
+        assert_eq!(node.output_type, IJType::Number(Some("a".to_string())));
 
         let mut context = ASTContext::new();
-        parse_str("var x: Fn(S<a>->S<a>)", &mut context)?;
+        parse_str("var x: Fn(N<a>->N<a>)", &mut context)?;
         let node = parse_str("~<-Fn(N<a>->N<a>) x", &mut context)?;
         assert_eq!(node.op, Operation::TypeConversion);
         assert_eq!(

--- a/ijzer/src/tensor.rs
+++ b/ijzer/src/tensor.rs
@@ -185,9 +185,8 @@ impl<T: Clone + Num> Tensor<T> {
 
         Some(result)
     }
-    pub fn reduce(&self, f: impl Fn(T, T) -> T) -> Tensor<T> {
-        let result = self.data.iter().cloned().reduce(f).unwrap();
-        Tensor::scalar(result)
+    pub fn reduce(&self, f: impl Fn(T, T) -> T) -> T {
+        self.data.iter().cloned().reduce(f).unwrap()
     }
     pub fn sub_tensor(&self, indices: Vec<Option<usize>>) -> Result<Tensor<T>> {
         if indices.len() != self.shape.len() {
@@ -326,11 +325,7 @@ impl<T: Clone + Num> Tensor<T> {
         Ok(result)
     }
     pub fn dot(&self, other: &Tensor<T>) -> Result<Tensor<T>> {
-        self.generalized_contraction(
-            other,
-            |x| x.reduce(|a, b| a + b).extract_scalar().unwrap(),
-            |a, b| a * b,
-        )
+        self.generalized_contraction(other, |x| x.reduce(|a, b| a + b), |a, b| a * b)
     }
 
     /// Concatenates a list of tensors of the same shape along a new axis
@@ -825,14 +820,14 @@ mod tests {
     fn test_reduce_multiplication() {
         let tensor = Tensor::from_vec(vec![2, 3, 4], Some(vec![3]));
         let result = tensor.reduce(|a, b| a * b);
-        assert_eq!(result.to_vec(), vec![24]);
+        assert_eq!(result, 24);
     }
 
     #[test]
     fn test_reduce_summation() {
         let tensor = Tensor::from_vec(vec![1, 2, 3, 4], Some(vec![4]));
         let result = tensor.reduce(|a, b| a + b);
-        assert_eq!(result.to_vec(), vec![10]);
+        assert_eq!(result, 10);
     }
 
     #[test]
@@ -878,7 +873,7 @@ mod tests {
         let result = tensor1
             .generalized_contraction(
                 &tensor2,
-                |x| x.reduce(|a, b| a + b).extract_scalar().unwrap(),
+                |x| x.reduce(|a, b| a + b),
                 |a, b| a * b,
             )
             .unwrap();
@@ -892,7 +887,7 @@ mod tests {
         let result = tensor1
             .generalized_contraction(
                 &tensor2,
-                |x| x.reduce(|a, b| a + b).extract_scalar().unwrap(),
+                |x| x.reduce(|a, b| a + b),
                 |a, b| a * b,
             )
             .unwrap();
@@ -906,7 +901,7 @@ mod tests {
         let result = tensor1
             .generalized_contraction(
                 &tensor2,
-                |x| x.reduce(|a, b| a + b).extract_scalar().unwrap(),
+                |x| x.reduce(|a, b| a + b),
                 |a, b| a * b,
             )
             .unwrap();
@@ -920,7 +915,7 @@ mod tests {
         let result = tensor1
             .generalized_contraction(
                 &tensor2,
-                |x| x.reduce(|a, b| a + b).extract_scalar().unwrap(),
+                |x| x.reduce(|a, b| a + b),
                 |a, b| a * b,
             )
             .unwrap();
@@ -934,7 +929,7 @@ mod tests {
         let result = tensor1
             .generalized_contraction(
                 &tensor2,
-                |x| x.reduce(|a, b| a + b).extract_scalar().unwrap(),
+                |x| x.reduce(|a, b| a + b),
                 |a, b| a * b,
             )
             .unwrap();

--- a/ijzer/src/tokens.rs
+++ b/ijzer/src/tokens.rs
@@ -193,9 +193,6 @@ pub enum Token {
     #[token("Fn")]
     FunctionType,
 
-    #[token("S", priority = 3)]
-    Scalar,
-
     #[token("T", priority = 3)]
     Tensor,
 
@@ -275,7 +272,6 @@ impl Display for Token {
             Self::RSqBracket => write!(f, "]"),
             Self::Reduction => write!(f, "/"),
             Self::FunctionType => write!(f, "Fn"),
-            Self::Scalar => write!(f, "S"),
             Self::Tensor => write!(f, "T"),
             Self::NumberToken => write!(f, "N"),
             Self::TypeDeclaration => write!(f, ":"),

--- a/ijzer_macro/tests/test_macro.rs
+++ b/ijzer_macro/tests/test_macro.rs
@@ -34,16 +34,16 @@ fn test_assign() {
     assert_eq!(y.to_vec(), x.to_vec());
 
     #[ijzer]
-    fn _test_assign_scalar() -> Tensor<i64> {
+    fn _test_assign_scalar() -> i64 {
         r#"
-        x: S = 1
+        x: N = 1
         x
         "#
     }
 
-    let x = Tensor::scalar(1);
+    let x = 1;
     let y = _test_assign_scalar();
-    assert_eq!(y.to_vec(), x.to_vec());
+    assert_eq!(y, x);
 }
 
 #[test]
@@ -144,7 +144,7 @@ fn test_return_function() {
 #[test]
 fn test_reduce() {
     #[ijzer]
-    fn _test_reduce(x: Tensor<f64>) -> Tensor<f64> {
+    fn _test_reduce(x: Tensor<f64>) -> f64 {
         r#"
         var x: T
         /+ x
@@ -152,12 +152,12 @@ fn test_reduce() {
     }
 
     let x = Tensor::from_vec(vec![1.0, 2.0], Some(vec![2]));
-    let expected = Tensor::from_vec(vec![3.0], Some(vec![1]));
+    let expected = 3.0;
     let y = _test_reduce(x.clone());
-    assert_eq!(y.to_vec(), expected.to_vec());
+    assert_eq!(y, expected);
 
     #[ijzer]
-    fn _test_reduce_2(x: Tensor<f64>, f: fn(f64, f64) -> f64) -> Tensor<f64> {
+    fn _test_reduce_2(x: Tensor<f64>, f: fn(f64, f64) -> f64) -> f64 {
         r#"
         var x: T
         var f: Fn(N,N->N)
@@ -166,38 +166,34 @@ fn test_reduce() {
     }
 
     let x = Tensor::from_vec(vec![1.0, 2.0, 3.0], Some(vec![3]));
-    let expected = Tensor::from_vec(vec![6.0], Some(vec![1]));
+    let expected = 6.0;
     let y = _test_reduce_2(x.clone(), |a, b| a * b);
-    assert_eq!(y.to_vec(), expected.to_vec());
+    assert_eq!(y, expected);
 }
 
 #[test]
 fn test_function_composition() {
     #[ijzer]
-    fn _test_function_composition() -> Tensor<i64> {
+    fn _test_function_composition() -> i64 {
         r#"
         @(/+,+) [1,2]<i64> [3,4]<i64>
         "#
     }
 
-    let expected = Tensor::from_vec(vec![10], Some(vec![1]));
     let y = _test_function_composition();
-    assert_eq!(y.to_vec(), expected.to_vec());
+    assert_eq!(y, 10);
 
     #[ijzer]
-    fn _test_external_function_composition(
-        f: fn(Tensor<i64>, Tensor<i64>) -> Tensor<i64>,
-    ) -> Tensor<i64> {
+    fn _test_external_function_composition(f: fn(Tensor<i64>, Tensor<i64>) -> Tensor<i64>) -> i64 {
         r#"
         var f: Fn(T,T->T)
         @(/+, f) [1,2] [3,4] 
         "#
     }
 
-    let expected = Tensor::from_vec(vec![11], Some(vec![1]));
     let y =
         _test_external_function_composition(|a, b| a.apply_binary_op(&b, |x, y| x * y).unwrap());
-    assert_eq!(y.to_vec(), expected.to_vec());
+    assert_eq!(y, 11);
 }
 
 #[test]
@@ -223,7 +219,12 @@ fn test_type_conversion() {
         "#
     }
 
-    let f = |a: Tensor<i64>, b: Tensor<i64>| a.apply_binary_op(&b, |x, y| x * y).unwrap().extract_scalar().unwrap();
+    let f = |a: Tensor<i64>, b: Tensor<i64>| {
+        a.apply_binary_op(&b, |x, y| x * y)
+            .unwrap()
+            .extract_scalar()
+            .unwrap()
+    };
     let expected = 120;
     let y = _test_type_conversion_func(f);
     assert_eq!(y, expected);
@@ -231,9 +232,9 @@ fn test_type_conversion() {
 
 #[test]
 fn test_apply_higher_function() {
-    type TensorFun = Box<dyn Fn(Tensor<i64>) -> Tensor<i64>>;
+    type ScalarFun = Box<dyn Fn(i64) -> i64>;
     #[ijzer]
-    fn _test_apply(f: fn(Tensor<i64>) -> TensorFun) -> Tensor<i64> {
+    fn _test_apply(f: fn(i64) -> ScalarFun) -> i64 {
         r#"
         var f: Fn(N-> Fn(N->N))
         .(f 2) 4
@@ -241,13 +242,13 @@ fn test_apply_higher_function() {
     }
 
     /// Turns `x` into a function that multiplies by `x`
-    fn f(x: Tensor<i64>) -> TensorFun {
-        Box::new(move |y: Tensor<i64>| x.apply_binary_op(&y, |a, b| a * b).unwrap())
+    fn f(x: i64) -> ScalarFun {
+        Box::new(move |y: i64| x * y)
     }
 
-    let expected = Tensor::scalar(8);
+    let expected = 8;
     let y = _test_apply(f);
-    assert_eq!(y.to_vec(), expected.to_vec());
+    assert_eq!(y, expected);
 }
 
 #[test]
@@ -319,7 +320,7 @@ fn test_tensor_builder() {
 #[test]
 fn test_apply_unary() {
     #[ijzer]
-    fn _test_apply(x: Tensor<i64>) -> Tensor<i64> {
+    fn _test_apply(x: Tensor<i64>) -> i64 {
         r#"
         var x: T
         .~/+ x
@@ -327,9 +328,8 @@ fn test_apply_unary() {
     }
 
     let x = Tensor::from_vec(vec![1, 2, 3, 4], Some(vec![2, 2]));
-    let expected = Tensor::from_vec(vec![10], Some(vec![1]));
     let y = _test_apply(x.clone());
-    assert_eq!(y.to_vec(), expected.to_vec());
+    assert_eq!(y, 10);
 }
 
 #[test]
@@ -504,7 +504,7 @@ fn test_svd_diag_mul() -> Result<()> {
 #[test]
 fn test_indexing() {
     #[ijzer]
-    fn _test_indexing_scalar(x: Tensor<i64>) -> Tensor<i64> {
+    fn _test_indexing_scalar(x: Tensor<i64>) -> i64 {
         r#"
         var x: T<i64>
         <|x[0,0]
@@ -513,7 +513,7 @@ fn test_indexing() {
 
     let x = Tensor::from_vec(vec![1, 2, 3, 4], Some(vec![2, 2]));
     let y = _test_indexing_scalar(x.clone());
-    assert_eq!(y.to_vec(), vec![1]);
+    assert_eq!(y, 1);
 
     #[ijzer]
     fn _test_indexing_tensor(x: Tensor<i64>) -> Tensor<i64> {
@@ -529,7 +529,6 @@ fn test_indexing() {
     let y = _test_indexing_tensor(x.clone());
     assert_eq!(y.to_vec(), vec![1, 2]);
 
-
     #[ijzer]
     fn _test_indexing_sub_tensor(x: Tensor<i64>) -> Tensor<i64> {
         r#"
@@ -539,6 +538,6 @@ fn test_indexing() {
     }
 
     let x = Tensor::from_vec(vec![1, 2, 3, 4], Some(vec![2, 2]));
-    let y = _test_indexing_tensor(x.clone());
+    let y = _test_indexing_sub_tensor(x.clone());
     assert_eq!(y.to_vec(), vec![1, 2]);
 }

--- a/ijzer_macro/tests/test_macro.rs
+++ b/ijzer_macro/tests/test_macro.rs
@@ -541,3 +541,21 @@ fn test_indexing() {
     let y = _test_indexing_sub_tensor(x.clone());
     assert_eq!(y.to_vec(), vec![1, 2]);
 }
+
+#[test]
+fn test_array_nested() {
+    #[ijzer]
+    fn _test_array_nested(x: Tensor<i64>) -> Tensor<i64> {
+        r#"
+        var x: T<i64>
+        y = x
+        z = x
+        y
+        "#
+    }
+
+    let x = Tensor::from_vec(vec![1, 2, 3, 4], Some(vec![2, 2]));
+    let y = _test_array_nested(x.clone());
+    assert_eq!(y.shape(), &[3, 2, 2]);
+    assert_eq!(y.to_vec(), vec![1, 2, 3, 4, 1, 2, 3, 4, 1, 2, 3, 4]);
+}

--- a/ijzer_macro/tests/test_macro.rs
+++ b/ijzer_macro/tests/test_macro.rs
@@ -548,8 +548,7 @@ fn test_array_nested() {
     fn _test_array_nested(x: Tensor<i64>) -> Tensor<i64> {
         r#"
         var x: T<i64>
-        y = x
-        z = x
+        y = [x,x,x]
         y
         "#
     }
@@ -558,4 +557,21 @@ fn test_array_nested() {
     let y = _test_array_nested(x.clone());
     assert_eq!(y.shape(), &[3, 2, 2]);
     assert_eq!(y.to_vec(), vec![1, 2, 3, 4, 1, 2, 3, 4, 1, 2, 3, 4]);
+}
+
+#[test]
+fn test_add_array_scalar() {
+    #[ijzer]
+    fn _test_add_array_scalar(x: Tensor<i64>, y: i64) -> Tensor<i64> {
+        r#"
+        var x: T<i64>
+        var y: N<i64>
+        + x y
+        "#
+    }
+
+    let x = Tensor::from_vec(vec![1, 2, 3, 4], Some(vec![2, 2]));
+    let y = 1;
+    let z = _test_add_array_scalar(x, y);
+    assert_eq!(z.to_vec(), vec![2, 3, 4, 5]);
 }

--- a/ijzer_macro/tests/test_macro.rs
+++ b/ijzer_macro/tests/test_macro.rs
@@ -216,17 +216,17 @@ fn test_type_conversion() {
     assert_eq!(y.to_vec(), expected.to_vec());
 
     #[ijzer]
-    fn _test_type_conversion_func(f: fn(Tensor<i64>, Tensor<i64>) -> Tensor<i64>) -> Tensor<i64> {
+    fn _test_type_conversion_func(f: fn(Tensor<i64>, Tensor<i64>) -> i64) -> i64 {
         r#"
-        var f: Fn(S,S->S)
+        var f: Fn(T,T->N)
         /<-Fn(N,N->N) f [1,2,3,4,5]
         "#
     }
 
-    let f = |a: Tensor<i64>, b: Tensor<i64>| a.apply_binary_op(&b, |x, y| x * y).unwrap();
-    let expected = Tensor::from_vec(vec![120], Some(vec![1]));
+    let f = |a: Tensor<i64>, b: Tensor<i64>| a.apply_binary_op(&b, |x, y| x * y).unwrap().extract_scalar().unwrap();
+    let expected = 120;
     let y = _test_type_conversion_func(f);
-    assert_eq!(y.to_vec(), expected.to_vec());
+    assert_eq!(y, expected);
 }
 
 #[test]
@@ -235,7 +235,7 @@ fn test_apply_higher_function() {
     #[ijzer]
     fn _test_apply(f: fn(Tensor<i64>) -> TensorFun) -> Tensor<i64> {
         r#"
-        var f: Fn(S-> Fn(S->S))
+        var f: Fn(N-> Fn(N->N))
         .(f 2) 4
         "#
     }


### PR DESCRIPTION
Remove support for scalars
Instead of scalar type `S` and number type `N` we just have number type `N`. The only reason this existed was to simplify the compiler when we didn't yet support number types. But it was a stupid idea, and we had to get rid of it.